### PR TITLE
screen과 audio를 녹화할 수 있는 기능 main에 merge 요청드립니다.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.1",
+    "react-s3": "^1.3.1",
     "react-scripts": "4.0.3",
     "simple-peer": "^9.11.0",
     "socket.io-client": "^2.3.0",
@@ -32,8 +33,8 @@
   },
   "scripts": {
     "start": "craco start",
-     "build": "craco build",
-     "test": "craco test",
+    "build": "craco build",
+    "test": "craco test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/client/src/Components/Record/Record.js
+++ b/client/src/Components/Record/Record.js
@@ -1,5 +1,9 @@
-import React from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import styled from 'styled-components';
+
+import { uploadFile } from 'react-s3';
+import { codeContext } from '../../Context/ContextProvider';
+
 
 const StyledSave = styled.div`
   position : absolute;
@@ -7,13 +11,88 @@ const StyledSave = styled.div`
   margin-left: 1200px;
 `;
 
+/* Change the values below to adjust video quality. */
+const displayMediaOptions = {
+  video: {
+    cursor: "always",
+    width: { max: 1920 },
+    height: { max: 1080 },
+    frameRate: 20
+  }
+};
+
 const Record = () => {
-  function save_record() {}
+  const recordRef = useRef();
+  const stopRef = useRef();
+  const { allAudioStreams } = useContext(codeContext);
+
+  useEffect(() => {
+    recordRef.current.onclick = async (e) => {
+      /* Merge all relevant streams including audio and screen into a single stream*/
+      const audioContext = new AudioContext();
+      const acDest = audioContext.createMediaStreamDestination();
+      for (let i = 0; i < allAudioStreams.length; i++) {
+        audioContext.createMediaStreamSource(allAudioStreams[i]).connect(acDest);
+      }
+      const screenStream = await navigator.mediaDevices.getDisplayMedia(displayMediaOptions);
+      const mergedStream = new MediaStream([...screenStream.getTracks(), ...acDest.stream.getTracks()]);
+
+      /* Initialize media recorder based on the merged stream above 
+       * and register event handlers for starting and stopping recording.
+       */
+      var chunks = [];
+      const mediaRecorder = new MediaRecorder(mergedStream, {
+        mimeType: 'video/webm; codecs=vp8'
+      });
+
+      mediaRecorder.start();
+
+      mediaRecorder.ondataavailable = (e) => {
+        chunks.push(e.data);
+      }
+
+      stopRef.current.onclick = () => {
+        mediaRecorder.stop();
+      }
+
+      mediaRecorder.onstop = async (e) => {
+        screenStream.getTracks()[0].stop();
+        
+        const blob = new Blob(chunks, { 'type': 'video/webm' })
+        const fileName = prompt("녹화 파일의 이름을 적어주세요.");
+        const recordFile = new File([blob], fileName + ".webm", {
+          type: blob.type,
+        })
+        console.log(recordFile);
+        const screenURL = window.URL.createObjectURL(recordFile);
+        console.log(screenURL);
+
+        const S3_BUCKET = 'screen-audio-record';
+        const REGION = 'ap-northeast-2';
+        const ACCESS_KEY = prompt("AWS ACCESS_KEY를 입력해주세요.");
+        const SECRET_ACCESS_KEY = prompt('AWS SECRET_ACCESS_KEY를 입력해주세요.');
+
+        const config = {
+          bucketName: S3_BUCKET,
+          region: REGION,
+          accessKeyId: ACCESS_KEY,
+          secretAccessKey: SECRET_ACCESS_KEY,
+        }
+
+        uploadFile(recordFile, config)
+          .then(data => console.log(data))
+          .catch(err => console.log(err))
+      }
+    }
+  }, [allAudioStreams]);
 
   return (
     <StyledSave>
-      <button className="record-button" onClick={save_record}>
+      <button className="record-button" ref={recordRef}>
         Record
+      </button>
+      <button className="record-button" ref={stopRef}>
+        Stop
       </button>
     </StyledSave>
   );

--- a/client/src/Context/ContextProvider.js
+++ b/client/src/Context/ContextProvider.js
@@ -8,6 +8,7 @@ const initialState = {
   codes: '',
   compileResult: '',
   roomInfo: '',
+  allAudioStreams: [],
 };
 
 // reducer는 action에서 받은 type에 따라서 state를 변경한다.
@@ -31,6 +32,11 @@ const reducer = (state, action) => {
         roomInfo: action.payload,
       };
 
+    case 'ADD_AUDIO_STREAM':
+      return {
+        ...state,
+        allAudioStreams: [...state.allAudioStreams, action.payload],
+      }
     default:
       throw new Error();
   }
@@ -61,6 +67,13 @@ const ContextProvider = ({ children }) => {
     });
   }
 
+  function addAudioStream(audioStream) {
+    dispatch({
+      type: "ADD_AUDIO_STREAM",
+      payload: audioStream,
+    });
+  }
+
   return (
     <codeContext.Provider
       //provider에 value props로 state와 dispatch를 내려준다.
@@ -71,6 +84,8 @@ const ContextProvider = ({ children }) => {
         getCompileResult,
         roomInfo: state.roomInfo,
         getRoomInfo,
+        allAudioStreams: state.allAudioStreams,
+        addAudioStream,
       }}
     >
       {children}

--- a/client/src/routes/Room.js
+++ b/client/src/routes/Room.js
@@ -16,6 +16,20 @@ import { WebrtcProvider } from 'y-webrtc';
 import Save from '../Components/Save/Save';
 import Record from '../Components/Record/Record';
 
+import { uploadFile } from 'react-s3';
+
+const S3_BUCKET ='screen-audio-record';
+const REGION ='ap-northeast-2';
+const ACCESS_KEY ='';
+const SECRET_ACCESS_KEY ='';
+
+const config = {
+    bucketName: S3_BUCKET,
+    region: REGION,
+    accessKeyId: ACCESS_KEY,
+    secretAccessKey: SECRET_ACCESS_KEY,
+}
+
 const StyledAudio = styled.audio`
   float: left;
 `;
@@ -190,9 +204,13 @@ const Room = () => {
     const startElem = document.getElementById("start");
     const stopElem = document.getElementById("stop");
 
+    /* Change the below values to improve video quality. */
     const displayMediaOptions = {
       video: {
-        cursor: "always"
+        cursor: "always",
+        width: {max: 800},
+        height: {max: 600},
+        frameRate: 10
       }
     };
 
@@ -218,10 +236,19 @@ const Room = () => {
         mediaRecorder.stop();
       }
 
-      mediaRecorder.onstop = (e) => {
+      mediaRecorder.onstop = async (e) => {
         const blob = new Blob(chunks, { 'type': 'video/webm' })
+        const fileName = prompt("녹화 파일의 이름을 적어주세요.");
+        const newFile = new File([blob], fileName+".webm", {
+          type: blob.type,
+        })
+        console.log(newFile);
         const screenURL = window.URL.createObjectURL(blob);
         console.log(screenURL);
+
+        uploadFile(newFile, config)
+          .then(data => console.log(data))
+          .catch(err => console.log(err))
       }
     }
   }, [allAudioStreams]);

--- a/client/src/routes/Room.js
+++ b/client/src/routes/Room.js
@@ -227,6 +227,7 @@ const Room = () => {
       }
 
       mediaRecorder.onstop = async (e) => {
+        screenStream.getTracks()[0].stop();
         const blob = new Blob(chunks, { 'type': 'video/webm' })
         const fileName = prompt("녹화 파일의 이름을 적어주세요.");
         const newFile = new File([blob], fileName + ".webm", {


### PR DESCRIPTION
screen & audio 녹화 로직은 다음과 같습니다.
1. 유저가 Record 버튼을 누른다.
2. MediaRecorder가 녹화를 요청한 유저의 screen stream과 방에 있는 전원의 audio stream을 함께 녹여 녹화를 시작한다.(MIME type은 video/webm; codec은 vp8)
3. Stop 버튼을 누른다.
4. 녹화가 중지되고, 유저의 메모리에 저장된 녹화 파일에 이름을 부여하고, AWS ACESS_KEY와 SECRET_KEY를 입력하면 지정된 S3로 전송이 된다.

특이사항
1. 현재 로직은 유저 컴퓨터의 리소스를 상당히 요구한다.
2. WebRTC 통신을 peer들과 하면서 이미 부하가 걸리고 있는 유저의 컴퓨터에, 비디오 encoding 작업까지 진행되면서 부하가 훨씬 심해진다. 4명이 동시에 접속하는 상황을 테스트했을 때까지는 괜찮았지만, 그 이상을 견딜 수 있을지는 추가 확인이 더 필요하다.
